### PR TITLE
.Net: Fix PlannerInstrumentation log message typo (#4904)

### DIFF
--- a/dotnet/src/InternalUtilities/planning/PlannerInstrumentation.cs
+++ b/dotnet/src/InternalUtilities/planning/PlannerInstrumentation.cs
@@ -204,13 +204,13 @@ internal static partial class PlannerInstrumentation
     [LoggerMessage(
         EventId = 0,
         Level = LogLevel.Error,
-        Message = "Plan creation failed. Error: {Message}")]
+        Message = "Plan execution failed. Error: {Message}")]
     static partial void LogInvokePlanError(this ILogger logger, Exception exception, string message);
 
     [LoggerMessage(
         EventId = 0,
         Level = LogLevel.Information,
-        Message = "Plan creation duration: {Duration}s.")]
+        Message = "Plan execution duration: {Duration}s.")]
     static partial void LogInvokePlanDuration(this ILogger logger, double duration);
 
 #pragma warning restore SYSLIB1006 // Multiple logging methods cannot use the same event id within a class


### PR DESCRIPTION
### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo! Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here. -->
There are two typos in the `PlannerInstrumentation` log message templates, which causes confusion.

### Description

<!-- Describe your changes, the overall approach, the underlying design. These notes will help understanding how your code works. Thanks! --> Fix the typos.

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting
script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
